### PR TITLE
Feature/#3 comment handling

### DIFF
--- a/dbrequests/tests/test_database.py
+++ b/dbrequests/tests/test_database.py
@@ -109,12 +109,25 @@ class TestDatabase:
                               'birth': ['2018-03-03', '2014-11-13', '2016-05-21', '2019-08-05']}) == df_out).all(axis=None)
 
     def test_percentage_escape(self, db):
-        df = db.send_query("SELECT * FROM cats WHERE owner LIKE 'Len%';", escape_percentage=True)
+        df = db.send_query("SELECT * FROM cats WHERE owner LIKE 'Cas%';", escape_percentage=True)
         df.birth = df.birth.astype(str)
-        assert (pd.DataFrame({'id': [1],
-                              'name': ['Sandy'],
-                              'owner': ['Lennon'],
-                              'birth': ['2015-01-03']}) == df).all(axis=None)
+        assert (pd.DataFrame({'id': [2],
+                              'name': ['Cookie'],
+                              'owner': ['Casey'],
+                              'birth': ['2013-11-13']}) == df).all(axis=None)
         with pytest.raises(ValueError):
             with pytest.warns(SyntaxWarning):
-                df = db.send_query("SELECT * FROM cats WHERE owner LIKE 'Len%';")
+                df = db.send_query("SELECT * FROM cats WHERE owner LIKE 'Cas%';")
+
+    def test_remove_comments(self, db):
+        df = db.send_query("""
+            SELECT name --, owner
+            from /*{comm}*/ cats
+            """, remove_comments=True)
+        assert df.shape == (3, 1)
+        assert df.name.to_list() == ['Sandy', 'Cookie', 'Charlie']
+        with pytest.raises(Exception):
+            df = db.send_query("""
+                SELECT name --, owner
+                from /*{comm}*/ cats
+                """)

--- a/dbrequests/tests/test_query.py
+++ b/dbrequests/tests/test_query.py
@@ -44,3 +44,14 @@ class TestQuery:
     def test_percentage_escape(self):
         query = Query("like a%", escape_percentage=True)
         assert query.text == "like a%%"
+
+    def test_remove_comments(self):
+        singleline = '''x --comment'''
+        assert Query(singleline, remove_comments=True).text == 'x '
+        singleline_break = '''
+x 
+--comment
+'''
+        assert Query(singleline_break, remove_comments=True).text == '\nx \n\n'
+        multiline = '''x/*y*/ x/*y*/'''
+        assert Query(multiline, remove_comments=True).text == 'x  x '


### PR DESCRIPTION
- added optional comment handling for sql input via regex splitting
- if used, no errors are thrown if {,} are used within comments
- the default uses the sql as it is. the behavior may be changed at database definition or send_query
- added tests.