### PR TITLE
resolves #27 port field in creds object

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,6 +45,8 @@
 ## Version 1.3.14
   - dbrequests.mysql:
     - see #32 for bugfix in send_query for empty result sets
+
+## Version 1.3.15
   - dbrequests:
     - see #27 for bugfix in Database class when specifiying a port in a
       credentials object.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,3 +45,12 @@
 ## Version 1.3.14
   - dbrequests.mysql:
     - see #32 for bugfix in send_query for empty result sets
+  - dbrequests:
+    - see #27 for bugfix in Database class when specifiying a port in a
+      credentials object.
+    - the argument 'creds' in the init method of a database class is now
+      deprecated
+    - the argument 'db_url' can now handle str and dict type; str is a
+      sqlalchemy url; a dict a credentials object
+    - credential objects can now have additional fields which will be used as
+      elements in connect_args for sqlalchemies create_engine: see #12

--- a/dbrequests/database.py
+++ b/dbrequests/database.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from pandas import DataFrame
 from sqlalchemy import create_engine, exc, inspect
 
-from .connection import Connection as DefaultConnection
+from .connection import Connection
 from .query import Query
 
 
@@ -40,8 +40,9 @@ class Database(object):
         - ...: all arguments are passed to sqlalchemy.create_engine
     """
 
+    _connection_class = Connection
+
     def __init__(self, db_url=None, sql_dir=None,
-                 connection_class=DefaultConnection,
                  escape_percentage=False, remove_comments=False, **kwargs):
 
         self.sql_dir = sql_dir or os.getcwd()
@@ -50,7 +51,6 @@ class Database(object):
         kwargs = self._init_db_url(db_url, **kwargs)
         self._init_engine(**kwargs)
         self._open = True
-        self.connection_class = connection_class
 
     def _init_db_url(self, db_url, **kwargs):
         if db_url is None:
@@ -110,7 +110,7 @@ class Database(object):
         """Get a connection from the sqlalchemy engine."""
         if not self._open:
             raise exc.ResourceClosedError('Database closed.')
-        return self.connection_class(self._engine.connect())
+        return self._connection_class(self._engine.connect())
 
     def __get_query_text(self, query, escape_percentage, remove_comments, **params):
         """Private wrapper for accessing the text of the query."""

--- a/dbrequests/database.py
+++ b/dbrequests/database.py
@@ -47,7 +47,7 @@ class Database(object):
             db_url = os.environ.get('DATABASE_URL')
             if db_url is None:
                 db_url = kwargs.pop('creds', None)
-                if db_url:
+                if db_url is not None:
                     warnings.warn(
                         "Parameter 'creds' is depreacated in favor of db_url.",
                         DeprecationWarning)

--- a/dbrequests/database.py
+++ b/dbrequests/database.py
@@ -29,9 +29,6 @@ class Database(object):
             - ...: further fields are added to 'connect_args'
     - sql_dir: (str|None) directory where to look for sql queries. Defaults to
       '.'.
-    - connection_class: (Connection) a connection class may be provided in
-      cases where default behaviours need to be extended. I.e. add a new 'mode'
-      in send_data.
     - escape_percentage: (bool) escape percentages when reading queries from a
       file.
     - remove_comments: (bool) remove comments when reading queries from a file.

--- a/dbrequests/database.py
+++ b/dbrequests/database.py
@@ -43,6 +43,16 @@ class Database(object):
     def __init__(self, db_url=None, sql_dir=None,
                  connection_class=DefaultConnection,
                  escape_percentage=False, remove_comments=False, **kwargs):
+
+        self.sql_dir = sql_dir or os.getcwd()
+        self._escape_percentage = escape_percentage
+        self._remove_comments = remove_comments
+        kwargs = self._init_db_url(db_url, **kwargs)
+        self._init_engine(**kwargs)
+        self._open = True
+        self.connection_class = connection_class
+
+    def _init_db_url(self, db_url, **kwargs):
         if db_url is None:
             db_url = os.environ.get('DATABASE_URL')
             if db_url is None:
@@ -71,16 +81,12 @@ class Database(object):
                 kwargs['connect_args'] = connect_args
         else:
             raise ValueError('db_url has to be a str or dict')
+        return kwargs
 
-        self.sql_dir = sql_dir or os.getcwd()
-        self._escape_percentage = escape_percentage
-        self._remove_comments = remove_comments
-        self._engine = self._init_engine(self.db_url, **kwargs)
-        self._open = True
-        self.connection_class = connection_class
-
-    def _init_engine(self, url, **kwargs):
-        return create_engine(url, **kwargs)
+    def _init_engine(self, **kwargs):
+        # We have this method, so that subclasses may override the init
+        # process.
+        self._engine = create_engine(self.db_url, **kwargs)
 
     def close(self):
         """Close the connection."""

--- a/dbrequests/mysql/database.py
+++ b/dbrequests/mysql/database.py
@@ -42,22 +42,21 @@ class Database(SuperDatabase):
     def send_data(self, df, table, mode='insert', **params):
         """Sends df to table in database.
 
-        Args:
-            - df (DataFrame): internally we use datatable Frame. Any object
-            that can be converted to a Frame may be supplied.
-            - table_name (str): Name of the table.
-            - mode ({'insert', 'truncate', 'replace',
-            'update'}): Mode of Data Insertion. Defaults to 'insert'.
-                - 'insert': appends data. Duplicates in the
-                primary keys are not replaced.
-                - 'truncate': drop the table, recreate it, then insert. No
-                rollback on error.
-                - 'delete': delete all rows in the table, then insert. This
-                operation can be rolled back on error, but can be very
-                expensive.
-                - 'replace': replaces (delete, then insert) duplicate primary
-                keys.
-                - 'update': updates duplicate primary keys
+        - df (DataFrame): internally we use datatable Frame. Any object
+        that can be converted to a Frame may be supplied.
+        - table_name (str): Name of the table.
+        - mode ({'insert', 'truncate', 'replace',
+        'update'}): Mode of Data Insertion. Defaults to 'insert'.
+            - 'insert': appends data. Duplicates in the
+            primary keys are not replaced.
+            - 'truncate': drop the table, recreate it, then insert. No
+            rollback on error.
+            - 'delete': delete all rows in the table, then insert. This
+            operation can be rolled back on error, but can be very
+            expensive.
+            - 'replace': replaces (delete, then insert) duplicate primary
+            keys.
+            - 'update': insert but with update on duplicate primary keys
         """
         if not isinstance(df, Frame):
             df = Frame(df)

--- a/dbrequests/mysql/database.py
+++ b/dbrequests/mysql/database.py
@@ -35,7 +35,7 @@ class Database(SuperDatabase):
             remove_comments=remove_comments,
             **kwargs)
 
-    def _init_engine(self, url, **kwargs):
+    def _init_engine(self, **kwargs):
         connect_args = kwargs.pop('connect_args', {})
         # This option is needed for send data via csv: #20
         connect_args['local_infile'] = connect_args.get('local_infile', 1)
@@ -43,8 +43,8 @@ class Database(SuperDatabase):
         # mysqldb can be difficult to install, so we also support
         # pymysql. Depending on the driver we pick the apropriate cursorclass.
         connect_args['cursorclass'] = connect_args.get(
-            'cursorclass', self._pick_cursorclass(url))
-        return super()._init_engine(url, connect_args=connect_args, **kwargs)
+            'cursorclass', self._pick_cursorclass(self.db_url))
+        super()._init_engine(connect_args=connect_args, **kwargs)
 
     def send_data(self, df, table, mode='insert', **params):
         """Sends df to table in database.

--- a/dbrequests/mysql/database.py
+++ b/dbrequests/mysql/database.py
@@ -26,14 +26,7 @@ class Database(SuperDatabase):
     the mysqldb driver, which can be 10x faster than the pymysql driver.
     """
 
-    def __init__(self, db_url=None, sql_dir=None,
-                 escape_percentage=False, remove_comments=False, **kwargs):
-        super().__init__(
-            db_url=db_url, sql_dir=sql_dir,
-            connection_class=MysqlConnection,
-            escape_percentage=escape_percentage,
-            remove_comments=remove_comments,
-            **kwargs)
+    _connection_class = MysqlConnection
 
     def _init_engine(self, **kwargs):
         connect_args = kwargs.pop('connect_args', {})

--- a/dbrequests/mysql/database.py
+++ b/dbrequests/mysql/database.py
@@ -36,7 +36,6 @@ class Database(SuperDatabase):
             **kwargs)
 
     def _init_engine(self, url, **kwargs):
-        # breakpoint()
         connect_args = kwargs.pop('connect_args', {})
         # This option is needed for send data via csv: #20
         connect_args['local_infile'] = connect_args.get('local_infile', 1)

--- a/dbrequests/mysql/tests/conftest.py
+++ b/dbrequests/mysql/tests/conftest.py
@@ -11,7 +11,7 @@ from dbrequests.mysql import Database
 CREDS = {
     'user': 'root',
     'password': 'root',
-    'host': '0.0.0.0:3307',
+    'host': '0.0.0.0',
     'db': 'test',
     'port': 3307
 }

--- a/dbrequests/mysql/tests/conftest.py
+++ b/dbrequests/mysql/tests/conftest.py
@@ -20,7 +20,7 @@ CREDS = {
 @pytest.yield_fixture(scope='module', params=['pymysql', 'mysqldb'])
 def db(request):
     """Create instances of database connections."""
-    creds = CREDS
+    creds = CREDS.copy()
     creds['driver'] = request.param
     db = Database(creds)
     try:
@@ -34,7 +34,7 @@ def db(request):
 @pytest.fixture(scope="module")
 def db_connect_args(request):
     """Create instance with connect args."""
-    creds = CREDS
+    creds = CREDS.copy()
     creds['driver'] = 'pymysql'
     # switch local_infile off so we can see that:
     # - override of defaults work

--- a/dbrequests/mysql/tests/conftest.py
+++ b/dbrequests/mysql/tests/conftest.py
@@ -22,7 +22,26 @@ def db(request):
     """Create instances of database connections."""
     creds = CREDS
     creds['driver'] = request.param
-    db = Database(creds=creds)
+    db = Database(creds)
+    try:
+        yield db
+    except BaseException as error:
+        raise error
+    finally:
+        db.close()
+
+
+@pytest.fixture(scope="module")
+def db_connect_args(request):
+    """Create instance with connect args."""
+    creds = CREDS
+    creds['driver'] = 'pymysql'
+    # switch local_infile off so we can see that:
+    # - override of defaults work
+    # - connect_args is appended from creds object
+    # - we expect working send_query and failing send_data
+    creds['local_infile'] = 0
+    db = Database(creds)
     try:
         yield db
     except BaseException as error:
@@ -33,7 +52,6 @@ def db(request):
 
 def run_docker_container():
     """Run mariadb-docker container and return proper url for access."""
-
     client = from_env()
     try:
         container = client.containers.run(
@@ -49,7 +67,6 @@ def run_docker_container():
         time.sleep(60)
     except APIError:
         container = client.containers.get('test-mariadb-database')
-
     return container
 
 

--- a/dbrequests/mysql/tests/test_connection.py
+++ b/dbrequests/mysql/tests/test_connection.py
@@ -1,0 +1,29 @@
+"""Testing connection bahaviours."""
+
+import pandas as pd
+import pytest
+from dbrequests.mysql.tests.conftest import set_up_cats as reset
+from sqlalchemy.exc import InternalError
+
+
+@pytest.mark.usefixtures('db_connect_args')
+class TestConnectionWithConnectArgs:
+    """Test that passing on connect_args works for credentials."""
+
+    def test_send_query(self, db_connect_args):
+        """Test that we have working connection."""
+        reset(db_connect_args)
+        res = db_connect_args.send_query('select 1 as x')
+        assert res.shape == (1, 1)
+
+    def test_send_data(self, db_connect_args):
+        """The connection has local_infile set to 0, so we expect an error."""
+        df_add = pd.DataFrame({
+            'name': ['Chill'],
+            'owner': ['Alex'],
+            'birth': ['2018-03-03']
+        })
+
+        reset(db_connect_args)
+        with pytest.raises(InternalError):
+            db_connect_args.send_data(df_add, 'cats', mode='insert')

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ class PublishCommand(Command):
 
 requires = ['SQLAlchemy;python_version>="3.0"',
             'pandas']
-version = '1.3.13'
+version = '1.3.14'
 
 
 def read(f):

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ class PublishCommand(Command):
 
 requires = ['SQLAlchemy;python_version>="3.0"',
             'pandas']
-version = '1.3.14'
+version = '1.3.15'
 
 
 def read(f):


### PR DESCRIPTION
- resolves #27 by deprecating the creds argument and using dicts as db_url
- addresses #12 by allowing the credentials dict to specify further arguments passed to connect_args

**Notes**
- I had to refactor the sub-class (mysql) quite a bit, so that I can take advantage of this new logic. I think this makes it a bit less complicated.
- I noticed that we can remove the connection_class argument from the Database class, and instead do something like:

```py
class Database:
    connection_class = DefaultConnection
    def __init__(self, ...):
        ...
```

This still allows us to override the Connection class in any derived sub-class and brings two advantages:
- (a): we can remove it from the public interface. The Database class is for the user and the argument does not make sense. A user is not supposed to even now about the Connection class; that's an implementation detail.
- (b): when we derive the subclass, we do not have to override the complete init method, and also do not need to keep track of upstream changes. Currently a new argument to init forces us to modify all derived sub-classes which override init. Yes, currently only one, but I have made several errors due to the suptle change in the call to the super init method already. My impression is, that defining that *global* constant may be more transparent.